### PR TITLE
readFileSync: toString -> utf8

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -2,5 +2,5 @@
 
 var fs = require('fs')
 var inliner = require('./')
-var inlined = inliner(fs.readFileSync(process.argv[2])).toString()
+var inlined = inliner(fs.readFileSync(process.argv[2], 'utf8')).toString()
 console.log(inlined)

--- a/index.js
+++ b/index.js
@@ -18,8 +18,8 @@ module.exports = function(html, base) {
       if (el.attr('rel') === 'stylesheet' && isLocal(href)) {
         var dir = path.dirname(href)
         var file = path.join(base, href)
-        var style = fs.readFileSync(file)
-        var inlined = inliner.css(style.toString(), { cssBasePath: dir })
+        var style = fs.readFileSync(file, 'utf8')
+        var inlined = inliner.css(style, { cssBasePath: dir })
         var inlinedTag = "<style>\n" + inlined.toString() + '\n</style>'
         el.replaceWith(inlinedTag)
       }


### PR DESCRIPTION
Add `utf8` param to [readFileSync](http://nodejs.org/api/fs.html#fs_fs_readfilesync_filename_options) instead of `toString` function.
